### PR TITLE
Removal of msg! on checks when errors are thrown

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -1,0 +1,17 @@
+name: Lint check, cargo build, cargo test test
+
+on: [push]
+
+jobs:
+  build_and_test:
+    name: marinade-sdk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: |
+          cargo fmt --check
+          cargo build
+          cargo test

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -8,7 +8,7 @@ url = "https://anchor.projectserum.com"
 
 [provider]
 cluster = "localnet"
-wallet = "/home/aankor/.config/solana/id.json"
+wallet = "~/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.3.1"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d05653bed5932064a287340dbc8a3cb298ee717e5c7ec3353d7cdb9f8fb7e1"
+checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/libs/marinade-sdk/src/checks.rs
+++ b/libs/marinade-sdk/src/checks.rs
@@ -1,6 +1,6 @@
 use solana_program::stake::state::StakeState;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
     pubkey::Pubkey,
 };
 use spl_token::state::Account as TokenAccount;
@@ -8,117 +8,67 @@ use spl_token::state::Mint;
 
 use crate::error::CommonError;
 
-pub fn check_min_amount(amount: u64, min_amount: u64, action_name: &str) -> ProgramResult {
+pub fn check_min_amount(amount: u64, min_amount: u64) -> ProgramResult {
     if amount >= min_amount {
         Ok(())
     } else {
-        msg!(
-            "{}: Number too low {} (min is {})",
-            action_name,
-            amount,
-            min_amount,
-        );
         Err(CommonError::NumberTooLow.into())
     }
 }
 
-pub fn check_address(
-    actual_address: &Pubkey,
-    reference_address: &Pubkey,
-    field_name: &str,
-) -> ProgramResult {
+pub fn check_address(actual_address: &Pubkey, reference_address: &Pubkey) -> ProgramResult {
     if actual_address == reference_address {
         Ok(())
     } else {
-        msg!(
-            "Invalid {} address: expected {} got {}",
-            field_name,
-            reference_address,
-            actual_address
-        );
         Err(ProgramError::InvalidArgument)
     }
 }
 
-pub fn check_owner_program<'info>(
-    account: &AccountInfo<'info>,
-    owner: &Pubkey,
-    field_name: &str,
-) -> ProgramResult {
+pub fn check_owner_program<'info>(account: &AccountInfo<'info>, owner: &Pubkey) -> ProgramResult {
     let actual_owner = account.owner;
     if actual_owner == owner {
         Ok(())
     } else {
-        msg!(
-            "Invalid {} owner_program: expected {} got {}",
-            field_name,
-            owner,
-            actual_owner
-        );
         Err(ProgramError::InvalidArgument)
     }
 }
 
-pub fn check_mint_authority(
-    mint: &Mint,
-    mint_authority: Pubkey,
-    field_name: &str,
-) -> ProgramResult {
+pub fn check_mint_authority(mint: &Mint, mint_authority: Pubkey) -> ProgramResult {
     if mint.mint_authority.contains(&mint_authority) {
         Ok(())
     } else {
-        msg!(
-            "Invalid {} mint authority {}. Expected {}",
-            field_name,
-            mint.mint_authority.unwrap_or_default(),
-            mint_authority
-        );
         Err(ProgramError::InvalidAccountData)
     }
 }
 
-pub fn check_freeze_authority(mint: &Mint, field_name: &str) -> ProgramResult {
+pub fn check_freeze_authority(mint: &Mint) -> ProgramResult {
     if mint.freeze_authority.is_none() {
         Ok(())
     } else {
-        msg!("Mint {} must have freeze authority not set", field_name);
         Err(ProgramError::InvalidAccountData)
     }
 }
 
-pub fn check_mint_empty(mint: &Mint, field_name: &str) -> ProgramResult {
+pub fn check_mint_empty(mint: &Mint) -> ProgramResult {
     if mint.supply == 0 {
         Ok(())
     } else {
-        msg!("Non empty mint {} supply: {}", field_name, mint.supply);
         Err(ProgramError::InvalidArgument)
     }
 }
 
-pub fn check_token_mint(token: &TokenAccount, mint: Pubkey, field_name: &str) -> ProgramResult {
+pub fn check_token_mint(token: &TokenAccount, mint: Pubkey) -> ProgramResult {
     if token.mint == mint {
         Ok(())
     } else {
-        msg!(
-            "Invalid token {} mint {}. Expected {}",
-            field_name,
-            token.mint,
-            mint
-        );
         Err(ProgramError::InvalidAccountData)
     }
 }
 
-pub fn check_token_owner(token: &TokenAccount, owner: &Pubkey, field_name: &str) -> ProgramResult {
+pub fn check_token_owner(token: &TokenAccount, owner: &Pubkey) -> ProgramResult {
     if token.owner == *owner {
         Ok(())
     } else {
-        msg!(
-            "Invalid token account {} owner {}. Expected {}",
-            field_name,
-            token.owner,
-            owner
-        );
         Err(ProgramError::InvalidAccountData)
     }
 }
@@ -132,10 +82,6 @@ pub fn check_stake_amount_and_validator(
 ) -> ProgramResult {
     let currently_staked = if let Some(delegation) = stake_state.delegation() {
         if delegation.voter_pubkey != *validator_vote_pubkey {
-            msg!(
-                "Invalid stake validator index. Need to point into validator {}",
-                validator_vote_pubkey
-            );
             return Err(ProgramError::InvalidInstructionData);
         }
         delegation.stake
@@ -144,11 +90,6 @@ pub fn check_stake_amount_and_validator(
     };
     // do not allow to operate on an account where last_update_delegated_lamports != currently_staked
     if currently_staked != expected_stake_amount {
-        msg!(
-            "Operation on a stake account not yet updated. expected stake:{}, current:{}",
-            expected_stake_amount,
-            currently_staked
-        );
         return Err(CommonError::StakeAccountNotUpdatedYet.into());
     }
     Ok(())

--- a/libs/marinade-sdk/src/state/liq_pool.rs
+++ b/libs/marinade-sdk/src/state/liq_pool.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::{entrypoint::ProgramResult, msg, program_error::ProgramError, pubkey::Pubkey};
+use solana_program::{entrypoint::ProgramResult, program_error::ProgramError, pubkey::Pubkey};
 
 use crate::{
     calc::proportional, checks::check_address, error::CommonError, located::Located,
@@ -59,11 +59,11 @@ impl LiqPool {
     }
 
     pub fn check_lp_mint(&mut self, lp_mint: &Pubkey) -> ProgramResult {
-        check_address(lp_mint, &self.lp_mint, "lp_mint")
+        check_address(lp_mint, &self.lp_mint)
     }
 
     pub fn check_liq_pool_msol_leg(&self, liq_pool_msol_leg: &Pubkey) -> ProgramResult {
-        check_address(liq_pool_msol_leg, &self.msol_leg, "liq_pool_msol_leg")
+        check_address(liq_pool_msol_leg, &self.msol_leg)
     }
 
     pub fn delta(&self) -> u32 {
@@ -102,21 +102,13 @@ impl LiqPool {
 
     pub fn check_liquidity_cap(
         &self,
-        transfering_lamports: u64,
+        transferring_lamports: u64,
         sol_leg_balance: u64,
     ) -> ProgramResult {
         let result_amount = sol_leg_balance
-            .checked_add(transfering_lamports)
-            .ok_or_else(|| {
-                msg!("SOL overflow");
-                ProgramError::InvalidArgument
-            })?;
+            .checked_add(transferring_lamports)
+            .ok_or_else(|| ProgramError::InvalidArgument)?;
         if result_amount > self.liquidity_sol_cap {
-            msg!(
-                "Liquidity cap reached {}/{}",
-                result_amount,
-                self.liquidity_sol_cap
-            );
             return Err(ProgramError::Custom(3782));
         }
         Ok(())
@@ -189,19 +181,11 @@ where
     }
 
     fn check_lp_mint_authority(&self, lp_mint_authority: &Pubkey) -> ProgramResult {
-        check_address(
-            lp_mint_authority,
-            &self.lp_mint_authority(),
-            "lp_mint_authority",
-        )
+        check_address(lp_mint_authority, &self.lp_mint_authority())
     }
 
     fn check_liq_pool_sol_leg_pda(&self, liq_pool_sol_leg_pda: &Pubkey) -> ProgramResult {
-        check_address(
-            liq_pool_sol_leg_pda,
-            &self.liq_pool_sol_leg_address(),
-            "liq_pool_sol_leg_pda",
-        )
+        check_address(liq_pool_sol_leg_pda, &self.liq_pool_sol_leg_address())
     }
 
     fn check_liq_pool_msol_leg_authority(
@@ -211,7 +195,6 @@ where
         check_address(
             liq_pool_msol_leg_authority,
             &self.liq_pool_msol_leg_authority(),
-            "liq_pool_msol_leg_authority",
         )
     }
 }

--- a/libs/marinade-sdk/src/state/marinade.rs
+++ b/libs/marinade-sdk/src/state/marinade.rs
@@ -3,7 +3,6 @@ use solana_program::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
     instruction::Instruction,
-    msg,
     program_error::ProgramError,
     program_pack::Pack,
     pubkey::Pubkey,
@@ -123,16 +122,12 @@ impl Marinade {
     }
 
     pub fn check_admin_authority(&self, admin_authority: &Pubkey) -> ProgramResult {
-        check_address(admin_authority, &self.admin_authority, "admin_authority")?;
+        check_address(admin_authority, &self.admin_authority)?;
         Ok(())
     }
 
     pub fn check_operational_sol_account(&self, operational_sol_account: &Pubkey) -> ProgramResult {
-        check_address(
-            operational_sol_account,
-            &self.operational_sol_account,
-            "operational_sol_account",
-        )
+        check_address(operational_sol_account, &self.operational_sol_account)
     }
 
     /*
@@ -145,17 +140,9 @@ impl Marinade {
         &self,
         treasury_msol_account: &AccountInfo<'info>,
     ) -> Result<bool, ProgramError> {
-        check_address(
-            treasury_msol_account.key,
-            &self.treasury_msol_account,
-            "treasury_msol_account",
-        )?;
+        check_address(treasury_msol_account.key, &self.treasury_msol_account)?;
 
         if treasury_msol_account.owner != &spl_token::ID {
-            msg!(
-                "treasury_msol_account {} is not a token account",
-                treasury_msol_account.key
-            );
             return Ok(false); // Not an error. Admins may decide to reject fee transfers to themselves
         }
 
@@ -164,28 +151,17 @@ impl Marinade {
                 if token_account.mint == self.msol_mint {
                     Ok(true)
                 } else {
-                    msg!(
-                        "treasury_msol_account {} has wrong mint {}. Expected {}",
-                        treasury_msol_account.key,
-                        token_account.mint,
-                        self.msol_mint
-                    );
                     Ok(false) // Not an error. Admins may decide to reject fee transfers to themselves
                 }
             }
-            Err(e) => {
-                msg!(
-                    "treasury_msol_account {} can not be parsed as token account ({})",
-                    treasury_msol_account.key,
-                    e
-                );
+            Err(_) => {
                 Ok(false) // Not an error. Admins may decide to reject fee transfers to themselves
             }
         }
     }
 
     pub fn check_msol_mint(&mut self, msol_mint: &Pubkey) -> ProgramResult {
-        check_address(msol_mint, &self.msol_mint, "msol_mint")
+        check_address(msol_mint, &self.msol_mint)
     }
 
     pub fn total_cooling_down(&self) -> u64 {
@@ -209,16 +185,8 @@ impl Marinade {
         let result_amount = self
             .total_lamports_under_control()
             .checked_add(transfering_lamports)
-            .ok_or_else(|| {
-                msg!("SOL overflow");
-                ProgramError::InvalidArgument
-            })?;
+            .ok_or_else(|| ProgramError::InvalidArgument)?;
         if result_amount > self.staking_sol_cap {
-            msg!(
-                "Staking cap reached {}/{}",
-                result_amount,
-                self.staking_sol_cap
-            );
             return Err(ProgramError::Custom(3782));
         }
         Ok(())
@@ -387,15 +355,11 @@ where
     }
 
     fn check_reserve_address(&self, reserve: &Pubkey) -> ProgramResult {
-        check_address(reserve, &self.reserve_address(), "reserve")
+        check_address(reserve, &self.reserve_address())
     }
 
     fn check_msol_mint_authority(&self, msol_mint_authority: &Pubkey) -> ProgramResult {
-        check_address(
-            msol_mint_authority,
-            &self.msol_mint_authority(),
-            "msol_mint_authority",
-        )
+        check_address(msol_mint_authority, &self.msol_mint_authority())
     }
 
     // Instructions

--- a/libs/marinade-sdk/src/state/stake_system.rs
+++ b/libs/marinade-sdk/src/state/stake_system.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
     pubkey::Pubkey,
 };
 
@@ -83,9 +83,8 @@ impl StakeSystem {
     }
 
     pub fn check_stake_list<'info>(&self, stake_list: &AccountInfo<'info>) -> ProgramResult {
-        check_address(stake_list.key, self.stake_list_address(), "stake_list")?;
+        check_address(stake_list.key, self.stake_list_address())?;
         if &stake_list.data.borrow().as_ref()[0..8] != StakeRecord::DISCRIMINATOR {
-            msg!("Wrong stake list account discriminator");
             return Err(ProgramError::InvalidAccountData);
         }
         Ok(())
@@ -121,11 +120,7 @@ where
     }
 
     fn check_stake_withdraw_authority(&self, stake_withdraw_authority: &Pubkey) -> ProgramResult {
-        check_address(
-            stake_withdraw_authority,
-            &self.stake_withdraw_authority(),
-            "stake_withdraw_authority",
-        )
+        check_address(stake_withdraw_authority, &self.stake_withdraw_authority())
     }
 
     fn stake_deposit_authority(&self) -> Pubkey {
@@ -143,10 +138,6 @@ where
     }
 
     fn check_stake_deposit_authority(&self, stake_deposit_authority: &Pubkey) -> ProgramResult {
-        check_address(
-            stake_deposit_authority,
-            &self.stake_deposit_authority(),
-            "stake_deposit_authority",
-        )
+        check_address(stake_deposit_authority, &self.stake_deposit_authority())
     }
 }

--- a/libs/marinade-sdk/src/state/validator_system.rs
+++ b/libs/marinade-sdk/src/state/validator_system.rs
@@ -141,23 +141,14 @@ impl ValidatorSystem {
         &self,
         validator_list: &AccountInfo<'info>,
     ) -> ProgramResult {
-        check_address(
-            validator_list.key,
-            self.validator_list_address(),
-            "validator_list",
-        )?;
+        check_address(validator_list.key, self.validator_list_address())?;
         if &validator_list.data.borrow().as_ref()[0..8] != ValidatorRecord::DISCRIMINATOR {
-            msg!("Wrong validator list account discriminator");
             return Err(ProgramError::InvalidAccountData);
         }
         Ok(())
     }
 
     pub fn check_validator_manager_authority(&self, manager_authority: &Pubkey) -> ProgramResult {
-        check_address(
-            manager_authority,
-            &self.manager_authority,
-            "validator_manager_authority",
-        )
+        check_address(manager_authority, &self.manager_authority)
     }
 }


### PR DESCRIPTION
Not using `msg!` on returned errors. The error can be handled by caller and then error msg is unwished.

NOTE: there is left one `msg!` for error on `get` from list. It seems to me it's place where it's reasonable to get that info. It could be removed as well if you find it as wrong.